### PR TITLE
Add env-based DB config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -355,3 +355,11 @@ Netbeans ή του Eclipse ως IDE.
 μορφοποίηση Excel ή PDF. Το ιστορικό ενός πελάτη θα πρέπει να περιλαμβάνει τα
 στοιχεία του πελάτη χωρίς όνομα χρήστη & κωδικό, τα αυτοκίνητά του και μια
 λίστα από όλα τα ραντεβού του, ανεξάρτητα της κατάστασής τους. 
+
+## Local Setup
+1. Ensure Node.js and npm are installed.
+2. From `backend/` run `npm install` and then `node server.js`.
+3. From `frontend/` run `npm install` and `npm start`.
+4. Copy `backend/.env.example` to `backend/.env` and update the values to match your MySQL setup. The server uses these variables for the database connection.
+5. Ensure a MySQL database named `workshop_management` exists (create it via phpMyAdmin in XAMPP or `mysql`).
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_USER=root
+DB_PASS=your_password
+DB_NAME=workshop_management

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "express": "^5.1.0",
     "express-session": "^1.18.1",
     "multer": "^2.0.1",
-    "mysql2": "^3.14.1"
+    "mysql2": "^3.14.1",
+    "dotenv": "^16.0.0"
   }
 }

--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,12 +1,16 @@
 // backend/src/config/db.js
 
 const mysql = require('mysql2/promise');
+const dotenv = require('dotenv');
+
+// Load environment variables from .env if present
+dotenv.config();
 
 const pool = mysql.createPool({
-  host: 'localhost',
-  user: 'root',
-  password: 'Zagori69!',
-  database: 'workshop_management',
+  host: process.env.DB_HOST || 'localhost',
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASS || '',
+  database: process.env.DB_NAME || 'workshop_management',
   waitForConnections: true,
   connectionLimit: 10,
   queueLimit: 0

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Car Workshop</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx,html}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- load database credentials from `.env`
- add `dotenv` and example environment file
- update local setup steps

## Testing
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false --passWithNoTests`
- `node backend/server.js`

------
https://chatgpt.com/codex/tasks/task_e_68494205f65c8333bffd895092a14d0f